### PR TITLE
:bug: Fix delegation ix

### DIFF
--- a/app/Assets/Scripts/Bolt/Hero.cs
+++ b/app/Assets/Scripts/Bolt/Hero.cs
@@ -255,7 +255,7 @@ namespace Hero
 
             public PublicKey DelegationRecord { get; set; }
 
-            public PublicKey DelegateAccountSeeds { get; set; }
+            public PublicKey DelegationMetadata { get; set; }
 
             public PublicKey DelegationProgram { get; set; }
 
@@ -294,9 +294,9 @@ namespace Hero
 
             public PublicKey DelegatedAccount { get; set; }
 
-            public PublicKey MagicContext { get; set; }
+            public PublicKey MagicContext { get; set; } = new("MagicContext1111111111111111111111111111111");
 
-            public PublicKey MagicProgram { get; set; }
+            public PublicKey MagicProgram { get; set; } = new("Magic11111111111111111111111111111111111111");
         }
 
         public class UpdateAccounts
@@ -310,18 +310,19 @@ namespace Hero
 
         public static class HeroProgram
         {
-            public const string ID = "11111111111111111111111111111111";
-            public static Solana.Unity.Rpc.Models.TransactionInstruction Delegate(DelegateAccounts accounts, long valid_until, uint commit_frequency_ms, PublicKey programId)
+            public const string ID = "GBzY8ujNDb1FNkJUXUUjKV5uZPqzi6AoKsPjsqFEHCeh";
+            public static Solana.Unity.Rpc.Models.TransactionInstruction Delegate(DelegateAccounts accounts, long validUntil, uint commitFrequencyMs, PublicKey programId = null)
             {
+                programId ??= new PublicKey(ID);
                 List<Solana.Unity.Rpc.Models.AccountMeta> keys = new()
-                {Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.Payer, true), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.Entity, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.Account, false), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.OwnerProgram, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.Buffer, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.DelegationRecord, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.DelegateAccountSeeds, false), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.DelegationProgram, false), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.SystemProgram, false)};
+                {Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.Payer, true), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.Entity, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.Account, false), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.OwnerProgram, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.Buffer, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.DelegationRecord, false), Solana.Unity.Rpc.Models.AccountMeta.Writable(accounts.DelegationMetadata, false), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.DelegationProgram, false), Solana.Unity.Rpc.Models.AccountMeta.ReadOnly(accounts.SystemProgram, false)};
                 byte[] _data = new byte[1200];
                 int offset = 0;
                 _data.WriteU64(9873113408189731674UL, offset);
                 offset += 8;
-                _data.WriteS64(valid_until, offset);
+                _data.WriteS64(validUntil, offset);
                 offset += 8;
-                _data.WriteU32(commit_frequency_ms, offset);
+                _data.WriteU32(commitFrequencyMs, offset);
                 offset += 4;
                 byte[] resultData = new byte[offset];
                 Array.Copy(_data, resultData, offset);

--- a/app/Assets/Scripts/Connectors/BaseComponentConnector.cs
+++ b/app/Assets/Scripts/Connectors/BaseComponentConnector.cs
@@ -30,7 +30,7 @@ namespace Connectors
                 ? Web3Utils.EphemeralWallet.ActiveRpcClient
                 : Web3.Wallet.ActiveRpcClient;
 
-        public static readonly PublicKey DelegationProgram = new("DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh");
+        private static readonly PublicKey DelegationProgram = new("DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh");
 
 
         //this comes from program deployment
@@ -329,7 +329,7 @@ namespace Connectors
                 Account = playerDataPda,
                 DelegationProgram = DelegationProgram,
                 DelegationRecord = FindDelegationProgramPda("delegation", playerDataPda),
-                // DelegationMetadata = FindDelegationProgramPda("delegation-metadata", playerDataPda),
+                DelegationMetadata = FindDelegationProgramPda("delegation-metadata", playerDataPda),
                 Buffer = FindBufferPda("buffer", playerDataPda, GetComponentProgramAddress()),
                 OwnerProgram = GetComponentProgramAddress(),
                 SystemProgram = SystemProgram.ProgramIdKey


### PR DESCRIPTION
## Description

- Core issue: `ProgramId` was not passed and failing because of a null pointer. Fixed the default.
- Small renaming/refactoring

## Notes
- The ProgramId not being set correctly needs to be fixed in the generator, tracked in https://github.com/magicblock-labs/Solana.Unity.Anchor/issues/7

## Local Setup

Start test validator:

```bash
bolt test --detach
```

Start ephemeral validator:

```bash
docker run -e ACCOUNTS_LIFECYCLE="ephemeral" -e ACCOUNTS_REMOTE="http://localhost:8899" -p 7899:8899 -p 7900:8900 magicblocklabs/validator
```


### Ephemeral Validator endpoints

- Ephemeral Validator RPC: "http://localhost:7899"
- Ephemeral Validator WS: "http://localhost:7900"
